### PR TITLE
Remove floating navbar from login page and update styling

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,10 +8,32 @@ const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const location = useLocation();
   const { user } = useAuth();
-  
+
   const isDashboardRoute = location.pathname.startsWith("/dashboard");
+  const isLoginPage = location.pathname === "/login" || location.pathname === "/signup" || location.pathname === "/forgot-password";
+
   if (user && isDashboardRoute) {
     return null;
+  }
+
+  // For login/signup pages, show only the logo
+  if (isLoginPage) {
+    return (
+      <nav className="fixed top-4 left-0 right-0 z-50">
+        <div className="max-w-7xl mx-auto px-6 lg:px-8">
+          <div className="flex justify-start items-center h-20">
+            <Link to="/" className="flex items-center space-x-3">
+              <img
+                src="https://cdn.builder.io/api/v1/assets/a59c9d8d677c4c99bcaffef64866607b/forgecollege-2c35f0?format=webp&width=800"
+                alt="Forge College"
+                className="h-12 w-auto"
+                style={{ minWidth: "120px" }}
+              />
+            </Link>
+          </div>
+        </div>
+      </nav>
+    );
   }
   
   const landingPageNavItems = [

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -42,16 +42,22 @@ export function Login() {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <Card className="w-full max-w-md">
+    <div className="flex items-center justify-center min-h-screen bg-forge-cream relative overflow-hidden">
+      {/* Decorative background elements */}
+      <div className="absolute inset-0 pointer-events-none">
+        <div className="absolute top-20 left-10 w-32 h-32 bg-forge-orange/5 rounded-full blur-3xl"></div>
+        <div className="absolute bottom-40 right-20 w-48 h-48 bg-forge-orange/10 rounded-full blur-2xl"></div>
+      </div>
+
+      <Card className="w-full max-w-md bg-white/95 backdrop-blur-sm border border-forge-orange/20 shadow-xl relative z-10">
         <CardHeader>
-          <CardTitle>Login</CardTitle>
+          <CardTitle className="text-forge-dark text-2xl font-bold">Login</CardTitle>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleLogin}>
             <div className="grid gap-4">
               <div className="grid gap-2">
-                <Label htmlFor="email">Email</Label>
+                <Label htmlFor="email" className="text-forge-dark font-medium">Email</Label>
                 <Input
                   id="email"
                   type="email"
@@ -59,30 +65,36 @@ export function Login() {
                   required
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
+                  className="border-forge-orange/20 focus:border-forge-orange focus:ring-forge-orange/20"
                 />
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="password">Password</Label>
-                <Input 
-                  id="password" 
-                  type="password" 
+                <Label htmlFor="password" className="text-forge-dark font-medium">Password</Label>
+                <Input
+                  id="password"
+                  type="password"
                   required
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
+                  className="border-forge-orange/20 focus:border-forge-orange focus:ring-forge-orange/20"
                 />
               </div>
-              {error && <p className="text-red-500 text-sm">{error}</p>}
-              <Button type="submit" className="w-full" disabled={loading}>
+              {error && <p className="text-red-500 text-sm bg-red-50 p-3 rounded-lg border border-red-200">{error}</p>}
+              <Button
+                type="submit"
+                className="w-full bg-forge-orange text-white hover:bg-forge-orange-light transition-all duration-200 shadow-lg hover:shadow-xl font-semibold py-3 rounded-xl"
+                disabled={loading}
+              >
                 {loading ? 'Loading...' : 'Login'}
               </Button>
               <div className="mt-4 text-center text-sm">
-                Don't have an account?{' '}
-                <Link to="/signup" className="underline">
+                <span className="text-forge-gray">Don't have an account?</span>{' '}
+                <Link to="/signup" className="text-forge-orange hover:text-forge-orange-light font-medium underline transition-colors">
                   Sign up
                 </Link>
               </div>
               <div className="text-center text-sm">
-                <Link to="/forgot-password" className="underline">
+                <Link to="/forgot-password" className="text-forge-orange hover:text-forge-orange-light font-medium underline transition-colors">
                   Forgot your password?
                 </Link>
               </div>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two main requests:
1. Remove the floating navigation bar and login button from the `/login` page while keeping the Forge College logo
2. Update the login page colors to better match the home page design standards

## Code changes

### Navbar Component (`src/components/Navbar.tsx`)
- Added detection for login/signup/forgot-password pages
- Created a simplified navbar variant for auth pages that shows only the Forge College logo
- Positioned logo on the left side with proper spacing and sizing

### Login Page (`src/pages/Login.tsx`)
- Updated background from `bg-gray-100` to `bg-forge-cream` to match brand colors
- Added decorative background elements with subtle orange accents
- Enhanced card styling with backdrop blur and brand-consistent borders
- Updated form elements to use Forge brand colors:
  - Labels now use `text-forge-dark` with medium font weight
  - Input fields have `border-forge-orange/20` with focus states
  - Submit button uses `bg-forge-orange` with hover effects
- Improved error message styling with background and border
- Updated link colors to use brand orange with hover transitions
- Enhanced overall visual hierarchy and spacing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a33f7ddae55d4e6fa692f37a05a818d5/swoosh-forge)

👀 [Preview Link](https://a33f7ddae55d4e6fa692f37a05a818d5-swoosh-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a33f7ddae55d4e6fa692f37a05a818d5</projectId>-->
<!--<branchName>swoosh-forge</branchName>-->