### PR TITLE
Fix Vercel config: replace routes with rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,8 +12,7 @@
       ]
     }
   ],
-  "routes": [
-    { "handle": "filesystem" },
-    { "src": "/(.*)", "dest": "/api/ssr" }
+  "rewrites": [
+    { "source": "/((?!api/).*)", "destination": "/api/ssr" }
   ]
 }


### PR DESCRIPTION
## Purpose

The user encountered a Vercel deployment error stating that `routes` cannot be present when other routing configurations like `rewrites`, `redirects`, `headers`, `cleanUrls` or `trailingSlash` are used. This change resolves the configuration conflict to enable successful deployments.

## Code changes

- Removed the deprecated `routes` configuration from `vercel.json`
- Replaced with `rewrites` configuration using the modern Vercel routing syntax
- Updated the routing pattern from `{ "src": "/(.*)", "dest": "/api/ssr" }` to `{ "source": "/((?!api/).*)", "destination": "/api/ssr" }`
- Removed the `{ "handle": "filesystem" }` route as it's handled automatically by Vercel
- The new rewrite pattern excludes API routes (`(?!api/)`) to prevent conflicts with existing API endpointsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2db697e8dd7e43559c4bc9b2e9218eab/glow-realm)

👀 [Preview Link](https://2db697e8dd7e43559c4bc9b2e9218eab-glow-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2db697e8dd7e43559c4bc9b2e9218eab</projectId>-->
<!--<branchName>glow-realm</branchName>-->